### PR TITLE
improve timeout behavior on jar download

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,18 +36,20 @@
   bf_url <- .bioformats_jar_url(ver)
 
   if ( !file.exists(bf_jar) ) {
-    # Use 100s instead of default of 60s for timing out the file download
+    # The default for timing out the file download is 60s
+    # Temporarily increase it if this is the case
+    orig_timeout <- getOption("timeout")
+    options(timeout = max(100, orig_timeout))
     tryCatch(utils::download.file(bf_url, bf_jar, mode = "wb", quiet = FALSE),
-             timeout = max(100, getOption("timeout")),
              error = function(e) {
                file.remove(bf_jar)
                stop(
                  "Failed to download Bio-Formats Java library.\n  Check your internet connection and try again. Consider setting the environment variable R_DEFAULT_INTERNET_TIMEOUT to a value higher than 100.",
                  call.=FALSE)
-             }
+             },
+    finally=options(timeout = orig_timeout)
     )
   }
-
 }
 
 .bioformats_jar_url <- function (ver) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,10 +36,14 @@
   bf_url <- .bioformats_jar_url(ver)
 
   if ( !file.exists(bf_jar) ) {
+    # Use 100s instead of default of 60s for timing out the file download
     tryCatch(utils::download.file(bf_url, bf_jar, mode = "wb", quiet = FALSE),
+             timeout = max(100, getOption("timeout")),
              error = function(e) {
                file.remove(bf_jar)
-               stop("failed to download Bio-Formats Java library.\n  Check your internet connection and try again.", call.=FALSE)
+               stop(
+                 "Failed to download Bio-Formats Java library.\n  Check your internet connection and try again. Consider setting the environment variable R_DEFAULT_INTERNET_TIMEOUT to a value higher than 100.",
+                 call.=FALSE)
              }
     )
   }


### PR DESCRIPTION
This increases the timeout to 100 seconds to reduce the frequency of timeouts for users. It also notes the R_DEFAULT_INTERNET_TIMEOUT environment variable available in more recent versions of R that can be set by a user in extreme cases.

This will serve as a reasonable stop gap. It may be better to raise an error in this situation rather than attempt to download the jar file internally. The bioformats jar is a dependency that should likely be installed in advance of package installation into `<package-dir>/java` instead of the user cache directory that is currently used upon loading the package. For example, fortran/C dependencies trigger errors upon installation by way of the dyn.load function... it is unfortunate that a similar mechanism does not seem to exist for java dependencies (or at least I can't spot it).

Resolves #26 